### PR TITLE
Add descriptive assertion messages

### DIFF
--- a/packages/create-universal-package/lib/tasks/preflight.js
+++ b/packages/create-universal-package/lib/tasks/preflight.js
@@ -10,17 +10,29 @@ module.exports = async function preflight(filePath, flow) {
   validateFields(pkg, flow);
 };
 
+function assertPkgField(pkg, field, fixture) {
+  assert.deepStrictEqual(
+    pkg[field],
+    fixture,
+    `package "${field}" definition incorrect, expected: ${JSON.stringify(
+      fixture,
+      null,
+      '  ',
+    )}`,
+  );
+}
+
 function validateFields(pkg, flow) {
   assert.strictEqual(pkg.main, './dist/index.js');
   assert.strictEqual(pkg.module, './dist/index.es.js');
-  assert.deepStrictEqual(pkg.browser, {
+  assertPkgField(pkg, 'browser', {
     './dist/index.js': './dist/browser.es5.js',
     './dist/index.es.js': './dist/browser.es5.es.js',
   });
-  assert.deepStrictEqual(pkg.es2015, {
+  assertPkgField(pkg, 'es2015', {
     './dist/browser.es5.es.js': './dist/browser.es2015.es.js',
   });
-  assert.deepStrictEqual(pkg.es2017, {
+  assertPkgField(pkg, 'es2017', {
     './dist/browser.es5.es.js': './dist/browser.es2017.es.js',
     './dist/browser.es2015.es.js': './dist/browser.es2017.es.js',
   });


### PR DESCRIPTION
When upgrading a project to the latest create-universal-package version I ran across errors which were hard to diagnose given multiple fields. Explicitly stating which field has a problem, along with the expected output will help folks upgrade.

Example of error message:

![image](https://user-images.githubusercontent.com/122602/35057841-06966120-fb6b-11e7-9e2c-d7a075276426.png)
