### PR TITLE
Add @babel/plugin-proposal-object-rest-spread

### DIFF
--- a/packages/create-universal-package/lib/build.js
+++ b/packages/create-universal-package/lib/build.js
@@ -294,6 +294,7 @@ function getBabelConfig({env, target, userBabelConfig, fastAsync, coverage}) {
         require.resolve('@babel/plugin-proposal-json-strings'),
         require.resolve('@babel/plugin-syntax-dynamic-import'),
         require.resolve('@babel/plugin-syntax-import-meta'),
+        require.resolve('@babel/plugin-proposal-object-rest-spread'),
       ])
       .filter(Boolean),
     // Never allow .babelrc usage

--- a/packages/create-universal-package/package.json
+++ b/packages/create-universal-package/package.json
@@ -21,6 +21,7 @@
     "@babel/core": "^7.0.0-beta.55",
     "@babel/plugin-proposal-class-properties": "7.0.0-beta.55",
     "@babel/plugin-proposal-json-strings": "7.0.0-beta.55",
+    "@babel/plugin-proposal-object-rest-spread": "^7.0.0-beta.55",
     "@babel/plugin-syntax-dynamic-import": "7.0.0-beta.55",
     "@babel/plugin-syntax-import-meta": "7.0.0-beta.55",
     "@babel/plugin-transform-flow-strip-types": "^7.0.0-beta.55",

--- a/yarn.lock
+++ b/yarn.lock
@@ -365,6 +365,13 @@
   dependencies:
     "@babel/plugin-syntax-object-rest-spread" "7.0.0-beta.31"
 
+"@babel/plugin-proposal-object-rest-spread@^7.0.0-beta.55":
+  version "7.0.0-beta.55"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.0.0-beta.55.tgz#b611bb83901bf05196237c516a8bb1117a2a9396"
+  dependencies:
+    "@babel/helper-plugin-utils" "7.0.0-beta.55"
+    "@babel/plugin-syntax-object-rest-spread" "7.0.0-beta.55"
+
 "@babel/plugin-proposal-optional-catch-binding@7.0.0-beta.31":
   version "7.0.0-beta.31"
   resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-optional-catch-binding/-/plugin-proposal-optional-catch-binding-7.0.0-beta.31.tgz#fb9388b396aeed371fc3bbb0bcd718a8f99bc917"
@@ -421,6 +428,12 @@
 "@babel/plugin-syntax-object-rest-spread@7.0.0-beta.31":
   version "7.0.0-beta.31"
   resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-object-rest-spread/-/plugin-syntax-object-rest-spread-7.0.0-beta.31.tgz#bd0f67210b3022182dc50d155393ccec720ca039"
+
+"@babel/plugin-syntax-object-rest-spread@7.0.0-beta.55":
+  version "7.0.0-beta.55"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-object-rest-spread/-/plugin-syntax-object-rest-spread-7.0.0-beta.55.tgz#990ea47e790d7d9a9d28469c6bcc15f580bf19e9"
+  dependencies:
+    "@babel/helper-plugin-utils" "7.0.0-beta.55"
 
 "@babel/plugin-syntax-optional-catch-binding@7.0.0-beta.31":
   version "7.0.0-beta.31"


### PR DESCRIPTION
It seems that this is necessary for our usage, but not mentioned in the babel docs when migrating from the stage- proposals.

Without this PR, I'm seeing errors like the following when attempting to upgrade CUP:
```
Support for the experimental syntax 'objectRestSpread' isn't currently enabled (38:11):

  36 | 
  37 |         return {
> 38 |           ...event,
     |           ^
  39 |           calculatedStats,
  40 |           timingValues: timing,
  41 |         };

Add @babel/plugin-proposal-object-rest-spread (https://git.io/vb4Ss) to the 'plugins' section of your Babel config to enable transformation.
```
