### PR TITLE
Add browser CJS build

### DIFF
--- a/fixture-package/package.json
+++ b/fixture-package/package.json
@@ -15,7 +15,10 @@
   ],
   "main": "./dist-node-cjs/index.js",
   "module": "./dist-node-esm/index.js",
-  "browser": "./dist-browser-esm/index.js",
+  "browser": {
+    "./dist-node-cjs/index.js": "./dist-browser-cjs/index.js",
+    "./dist-node-esm/index.js": "./dist-browser-esm/index.js"
+  },
   "scripts": {
     "clean": "cup clean",
     "build": "cup build",

--- a/packages/create-universal-package/preflight.js
+++ b/packages/create-universal-package/preflight.js
@@ -2,6 +2,7 @@
 
 const fs = require('fs');
 const {promisify} = require('util');
+const assert = require('assert');
 
 const readFile = promisify(fs.readFile);
 
@@ -11,16 +12,21 @@ module.exports = async function preflight(filePath /*: string */) {
   try {
     assertPkgField(pkg, 'main', './dist-node-cjs/index.js');
     assertPkgField(pkg, 'module', './dist-node-esm/index.js');
-    assertPkgField(pkg, 'browser', './dist-browser-esm/index.js');
+    assertPkgField(pkg, 'browser', {
+      './dist-node-cjs/index.js': './dist-browser-cjs/index.js',
+      './dist-node-esm/index.js': './dist-browser-esm/index.js',
+    });
   } catch (err) {
     throw err;
   }
 };
 
 function assertPkgField(pkg, field, expected) {
-  if (pkg[field] !== expected) {
+  try {
+    assert.deepEqual(pkg[field], expected);
+  } catch (err) {
     throw new Error(
-      `package "${field}" definition incorrect, expected: ${JSON.stringify(
+      `package.json "${field}" entry incorrect, expected value: ${JSON.stringify(
         expected,
         null,
         '  ',

--- a/packages/create-universal-package/worker.js
+++ b/packages/create-universal-package/worker.js
@@ -30,6 +30,15 @@ async function buildFile(root, filename) {
 
   return Promise.all([
     write(
+      `${root}/dist-browser-cjs/${relative}`,
+      build(
+        ast,
+        source,
+        baseConfig,
+        getPlugins({cjs: true, target: 'browser'}),
+      ),
+    ),
+    write(
       `${root}/dist-browser-esm/${relative}`,
       build(ast, source, baseConfig, getPlugins({target: 'browser'})),
     ),


### PR DESCRIPTION
This improves compatibility with Jest, because Jest:
1. Does not add support for ESM syntax out of the box
2. Skips transformation of `node_modules` by default
