### PR TITLE
Rename package and bin files

### DIFF
--- a/fixture-package/package.json
+++ b/fixture-package/package.json
@@ -20,8 +20,8 @@
     "./dist-node-esm/index.js": "./dist-browser-esm/index.js"
   },
   "scripts": {
-    "clean": "cup clean",
-    "build": "cup build",
+    "clean": "cup4 clean",
+    "build": "cup4 build",
     "lint": "eslint src/**",
     "prepublish": "npm run build"
   },
@@ -29,7 +29,7 @@
     "@babel/core": "^7.2.2",
     "@babel/preset-react": "^7.0.0",
     "babel-eslint": "^10.0.1",
-    "create-universal-package": "^4.1.0",
+    "@rtsao/create-universal-package-4": "^4.1.0",
     "enzyme": "^3.8.0",
     "enzyme-adapter-react-16": "^1.7.1",
     "eslint": "5.x",

--- a/packages/create-universal-package/package.json
+++ b/packages/create-universal-package/package.json
@@ -1,14 +1,14 @@
 {
-  "name": "create-universal-package",
+  "name": "@rtsao/create-universal-package-4",
   "version": "4.1.0",
   "description": "A CLI for developing universal (Node.js and browser) JavaScript packages.",
   "author": "Ryan Tsao <ryan.j.tsao@gmail.com>",
   "repository": "rtsao/create-universal-package",
   "main": "index.js",
   "bin": {
-    "cup": "./bin/index.js",
-    "cup-build": "./bin/build.js",
-    "cup-clean": "./bin/clean.js"
+    "cup4": "./bin/index.js",
+    "cup4-build": "./bin/build.js",
+    "cup4-clean": "./bin/clean.js"
   },
   "dependencies": {
     "@babel/core": "^7.2.2",


### PR DESCRIPTION
This is a temporary workaround for multiple cup versions in the fusion monorepo. I scoped the package name since it's only gonna be temporarily used.

Alternative approach is to resolve #1 and rename to something like `universal-package` with `upkg` bin name, but that's a bit more work since it'd require renaming the eslint plugins and whatnot.

NOTE: Probably should make a temporary branch and change this PR target branch to it