### PR TITLE
Fix cup/no-undef rule detection of env if conditional else case

### DIFF
--- a/packages/eslint-plugin-cup/lib/rules/no-undef.js
+++ b/packages/eslint-plugin-cup/lib/rules/no-undef.js
@@ -66,12 +66,9 @@ function inverseEnv(env) {
 function lookupEnv(node) {
   let parent = node.parent;
   while (parent) {
-    if (parent.type === 'IfStatement' && parent.test.type === 'Identifier') {
-      if (matchesEnv(parent.test.name)) {
-        return parent.test.name;
-      }
-    } else if (
-      parent.type === 'ConditionalExpression' &&
+    if (
+      (parent.type === 'IfStatement' ||
+        parent.type === 'ConditionalExpression') &&
       parent.test.type === 'Identifier'
     ) {
       if (matchesEnv(parent.test.name)) {

--- a/packages/eslint-plugin-cup/test/lib/rules/no-undef.js
+++ b/packages/eslint-plugin-cup/test/lib/rules/no-undef.js
@@ -14,6 +14,10 @@ ruleTester.run('no-undef', rule, {
       code: 'function a(){}if (__NODE__) {a(__dirname)}',
       globals: {__NODE__: false},
     },
+    {
+      code: 'function a(){}if (__BROWSER__) {a(window)} else {a(process)}',
+      globals: {__BROWSER__: false},
+    },
     {code: 'var foo = __NODE__ ? process : window', globals: {__NODE__: false}},
 
     'var a = 1, b = 2; a;',


### PR DESCRIPTION
The inverse environment should be use in the alternate case of an if conditional