### PR TITLE
Fix relative path in generated source maps

### DIFF
--- a/packages/create-universal-package/worker.js
+++ b/packages/create-universal-package/worker.js
@@ -59,7 +59,10 @@ async function buildFile(root, filename) {
 
   const source = await fileContents;
 
-  baseConfig.sourceFileName = path.relative(root, filename);
+  baseConfig.sourceFileName = path.relative(
+    path.join(root, '__dist__'),
+    filename
+  );
 
   const ast = babel.parseSync(source, baseConfig);
 


### PR DESCRIPTION
Fix paths to original sources in generated source maps to account for one extra level of nesting (the dist folder), so that original source filepath resolved correctly by climbing one level up (sources are resolved relative to the source map):

Before:
```
  "sources": [
    "src/foo/a.js"
  ],
```

After:
```
  "sources": [
    "../src/foo/a.js"
  ],
```